### PR TITLE
fix(upgrade-os): Don't allow to upgrade jails when OS has a pending upgrade

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [UPGRADE-OS] Incorrect date format
 - [UPGRADE-OS] Correctly Download and use the upgrade when upgrading only one or more jails and base is up-to-date
 - [UPGRADE-OS] Set correct flags for system upgrades when installing in jails, with BE activated
+- [UPGRADE-OS] Prevent upgrading jails when OS has a pending upgrade, as /.jail_system/ folder is kept with root filesystem dataset
 ### Changed
 - [UPGRADE-OS] Default to creating/using a BE when installing root upgrade
 

--- a/usr/local/share/vulture-utils/upgrade-os.sh
+++ b/usr/local/share/vulture-utils/upgrade-os.sh
@@ -120,10 +120,8 @@ initialize() {
         exit 1
     fi
 
-    if [ "${upgrade_root}" -gt 0 ]; then
-        has_pending_BE || exit 1
-        has_upgraded_kernel || exit 1
-    fi
+    has_pending_BE || exit 1
+    has_upgraded_kernel || exit 1
 
     echo "[${TIME_START}] Beginning ${_action_str}"
 


### PR DESCRIPTION
jails' base might be the /.jail_system/ folder, that is owned by the root dataset
if a BE is pending, changes will be reverted on reboot