### PR TITLE
fix(upgrade-os): Adds flags '-i' to hbsd-update, in order to ignore the version check to force update/rollback to a specific version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [UPGRADE-PKG] Restart GUI/Portal services only at the end of an upgrade
 ### Fixed
 - [UPGRADE-PKG] Only restart jail service(s) when corresponding package is upgraded
+- [UPGRADE-OS] Do not check version when specifying a version to install
 
 
 ## [1.0.4] - 2025-10-29

--- a/usr/local/share/vulture-utils/upgrade-os.sh
+++ b/usr/local/share/vulture-utils/upgrade-os.sh
@@ -92,8 +92,9 @@ update_system() {
         fi
         if [ -n "$system_version" ]; then
             # Add -U as non-last update versions cannot be verified
+            # Add -i to disable version check
             echo "[!] Custom version of system update selected, this version will be installed without signature verification!"
-            _options="${_options} -v $system_version -U"
+            _options="${_options} -v $system_version -U -i"
         fi
         if [ -z "$_jail" ] && [ $snapshot_system -gt 0 ]; then
             _options="${_options} -b ${_snap_name}"


### PR DESCRIPTION
[UPGRADE-OS] Adds flags '-i' to hbsd-update, in order to ignore the version check to force update/rollback to a specific version